### PR TITLE
added gdx-tools dependency alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ To use the extension libraries, first insert the aliases into
 * `libGdxBox2d`
 * `libGdxFreeType`
 * `libGdxControllers`
+* `libGdxTools`
 
 Then, append the corresponding `Desktop` or `Android` versions to
 `libraryDependencies` in the corresponding projects.

--- a/src/main/scala/co/technius/sbtlibgdx/LibGdxPlugin.scala
+++ b/src/main/scala/co/technius/sbtlibgdx/LibGdxPlugin.scala
@@ -21,6 +21,8 @@ object LibGdxPlugin extends AutoPlugin {
     val libGdxFreeType = gdxDependency("gdx-freetype")
 
     val libGdxControllers = gdxDependency("gdx-controllers")
+    
+    val libGdxTools = gdxDependency("gdx-tools")
 
     val libGdxBox2dDesktop = Def.setting {
       Seq(libGdxBox2d.value, desktopDependency("gdx-box2d-platform").value)


### PR DESCRIPTION
I needed gdx-tools to start the particle editor really easy. Added it as alias to the plugin
